### PR TITLE
docs: add missing import setup_python to steps example (#77)

### DIFF
--- a/docs/steps.rst
+++ b/docs/steps.rst
@@ -44,7 +44,7 @@ Example job
 .. code-block:: python
 
    from pygha.decorators import job
-   from pygha.steps import run, checkout, echo, uses
+   from pygha.steps import run, checkout, echo, uses, setup_python
 
    @job(name="quality", depends_on=["build"], runs_on="ubuntu-latest")
    def lint_and_test():


### PR DESCRIPTION
## Description
This PR fixes issue #77. I added the missing setup_python import to the example code in docs/steps.rst as requested
## Related Issue
## Type of Change
- [X] Documentation update

## Checklist
- [X ] All tests pass locally (`pytest`)
- [X ] I have written or updated tests for any changes
- [X ] I have updated the documentation for any changes
- [X ] I have updated `changelog.md` and referred to the issue in the changelog entry
